### PR TITLE
Issues #29 & #30: Fixed Typo in CONTRIBUTING.md and Linked to README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ This project uses GitHub Issues to track work tickets. If you would like to repo
 
 We welcome code contributions to this project! If you would like to contribute by developing for this project, please select a work ticket that is in the "Ready" state from the [Issues page][issues].
 
-When you have successfully implemented the feature described by the work ticket, please [squash]squashGitDoc the relevant commits into one feature commit, include the issue number in the commit message, and issue a pull request to the development branch of the project. The team will review your pull request, and may ask clarifying questions or request changes- please actively participate in discussion. Once the team has approved your pull request, your contributions will be merged!
+When you have successfully implemented the feature described by the work ticket, please [squash][squashGitDoc] the relevant commits into one feature commit, include the issue number in the commit message, and issue a pull request to the development branch of the project. The team will review your pull request, and may ask clarifying questions or request changes- please actively participate in discussion. Once the team has approved your pull request, your contributions will be merged!
 
 
 [issues]: https://github.com/mozillascience/software-citation-tools/issues

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Software Citation Tools is a project proposed and overseen by Mozilla Science La
 Even though the team heading the project is doing this as a senior project, anyone is free to contribute! The RIT Software Engineering department has given approval for anyone to help out in any way without affecting the team's grade. Please feel free to contribute in any way you want!
 
 ##Contributing
-Right now we're trying to build a set of requirements and features by getting responses to some [questions](https://github.com/mozillascience/software-citation-tools/issues?q=is%3Aissue+is%3Aopen+label%3ADiscussion) we made.
+We encourage you to contribute to this project in any way you can! An important goal of this project is to foster a community around these tools. If you'd like to be a part of that community, read our [contributing guide](https://github.com/mozillascience/software-citation-tools/blob/master/CONTRIBUTING.md) for more information.


### PR DESCRIPTION
Fixed the formatting typo in CONTRIBUTING.md to fix the Markdown link. This resolves issue #29.

Rewrote the Contributing section of README.md, linking and directing potential contributors to CONTRIBUTING.md. This resolves issue #30.